### PR TITLE
fix: Address Copilot review on PR #21

### DIFF
--- a/src/TextToSpeech.Providers.GoogleCloud/GoogleCloudMultiKeyTtsProvider.cs
+++ b/src/TextToSpeech.Providers.GoogleCloud/GoogleCloudMultiKeyTtsProvider.cs
@@ -104,9 +104,9 @@ public sealed class GoogleCloudMultiKeyTtsProvider : ITtsProvider, IDisposable
             _persistLoopTask = Task.Run(() => PersistLoopAsync(_persistCts.Token));
 
             // Hydrate asynchronously to avoid sync-over-async on the constructor
-            // path. Synthesis is safe before hydration completes - keys default
-            // to Available, and any persisted "parked" state simply becomes
-            // visible once the load resolves.
+            // path. SynthesizeAsync awaits this task before touching any key
+            // state, so hydration cannot clobber counters incremented by an
+            // in-flight call (the previous design had a clobber race).
             _hydrationTask = Task.Run(HydrateFromStoreAsync);
         }
 
@@ -117,9 +117,9 @@ public sealed class GoogleCloudMultiKeyTtsProvider : ITtsProvider, IDisposable
 
     /// <summary>
     /// Awaits initial hydration from the configured <see cref="IApiKeyUsageStore"/>.
-    /// Optional - synthesis is safe to invoke before this completes; in that
-    /// window keys behave as freshly-created (Available, zero counters). Useful
-    /// for dashboards that want to render the persisted state without races.
+    /// <see cref="SynthesizeAsync"/> already awaits this internally, so callers
+    /// only need it to render a consistent snapshot via <see cref="GetKeysUsage"/>
+    /// or <see cref="GetInfoAsync"/> before any synthesis has happened.
     /// </summary>
     public Task WaitForHydrationAsync() => _hydrationTask;
 
@@ -135,6 +135,15 @@ public sealed class GoogleCloudMultiKeyTtsProvider : ITtsProvider, IDisposable
         {
             _logger.LogError("No API keys configured for GoogleCloudMultiKey provider");
             return TtsResult.Fail("No API keys configured", Name, stopwatch.Elapsed);
+        }
+
+        // Wait for initial hydration before touching any key state. Without
+        // this, hydration could clobber counters that a concurrent synthesis
+        // already incremented (race observed in PR #21 review). Subsequent
+        // calls hit a completed task - no measurable cost.
+        if (!_hydrationTask.IsCompletedSuccessfully)
+        {
+            await _hydrationTask.ConfigureAwait(false);
         }
 
         var charCount = request.Text?.Length ?? 0;
@@ -764,8 +773,14 @@ public sealed class GoogleCloudMultiKeyTtsProvider : ITtsProvider, IDisposable
     }
 
     /// <inheritdoc />
-    public Task<TtsProviderInfo> GetInfoAsync(CancellationToken cancellationToken = default)
+    public async Task<TtsProviderInfo> GetInfoAsync(CancellationToken cancellationToken = default)
     {
+        // Surface persisted state on the first call after restart.
+        if (!_hydrationTask.IsCompletedSuccessfully)
+        {
+            await _hydrationTask.ConfigureAwait(false);
+        }
+
         var czechMaleVoices = new[]
         {
             "cs-CZ-Chirp3-HD-Achird", "cs-CZ-Chirp3-HD-Algenib", "cs-CZ-Chirp3-HD-Algieba",
@@ -803,13 +818,13 @@ public sealed class GoogleCloudMultiKeyTtsProvider : ITtsProvider, IDisposable
             lastSuccess = _lastSuccessTime;
         }
 
-        return Task.FromResult(new TtsProviderInfo
+        return new TtsProviderInfo
         {
             Name = Name,
             Status = status,
             LastSuccessTime = lastSuccess,
             SupportedVoices = voices
-        });
+        };
     }
 
     /// <inheritdoc />

--- a/src/TextToSpeech.Providers.GoogleCloud/GoogleCloudMultiKeyTtsProvider.cs
+++ b/src/TextToSpeech.Providers.GoogleCloud/GoogleCloudMultiKeyTtsProvider.cs
@@ -140,10 +140,11 @@ public sealed class GoogleCloudMultiKeyTtsProvider : ITtsProvider, IDisposable
         // Wait for initial hydration before touching any key state. Without
         // this, hydration could clobber counters that a concurrent synthesis
         // already incremented (race observed in PR #21 review). Subsequent
-        // calls hit a completed task - no measurable cost.
+        // calls hit a completed task - no measurable cost. Honors the caller's
+        // cancellation token so a slow/hung backing store cannot pin the call.
         if (!_hydrationTask.IsCompletedSuccessfully)
         {
-            await _hydrationTask.ConfigureAwait(false);
+            await _hydrationTask.WaitAsync(cancellationToken).ConfigureAwait(false);
         }
 
         var charCount = request.Text?.Length ?? 0;
@@ -775,10 +776,11 @@ public sealed class GoogleCloudMultiKeyTtsProvider : ITtsProvider, IDisposable
     /// <inheritdoc />
     public async Task<TtsProviderInfo> GetInfoAsync(CancellationToken cancellationToken = default)
     {
-        // Surface persisted state on the first call after restart.
+        // Surface persisted state on the first call after restart. Honors
+        // the caller's cancellation so a slow store can't hang dashboards.
         if (!_hydrationTask.IsCompletedSuccessfully)
         {
-            await _hydrationTask.ConfigureAwait(false);
+            await _hydrationTask.WaitAsync(cancellationToken).ConfigureAwait(false);
         }
 
         var czechMaleVoices = new[]

--- a/src/TextToSpeech.Providers.GoogleCloud/IApiKeyUsageStore.cs
+++ b/src/TextToSpeech.Providers.GoogleCloud/IApiKeyUsageStore.cs
@@ -29,9 +29,13 @@ public interface IApiKeyUsageStore
 }
 
 /// <summary>
-/// Persisted snapshot of a single API key's usage and health. Restored verbatim
-/// on provider startup, so a rate-limited / quota-exceeded / invalid key keeps
-/// its status across process restarts.
+/// Persisted snapshot of a single API key's usage and health. Loaded on startup
+/// and used to seed the in-memory state, with normalization applied: elapsed
+/// cooldowns reset to <see cref="ApiKeyState.Available"/>; counters reset when
+/// the persisted month no longer matches the current UTC month; and a key is
+/// forced to <see cref="ApiKeyState.MonthlyLimitExceeded"/> if its counter
+/// already meets the configured limit. The persisted record is therefore not
+/// applied verbatim - it is reconciled with current wall-clock state.
 /// </summary>
 public sealed record ApiKeyUsageRecord
 {

--- a/src/TextToSpeech.Providers.GoogleCloud/IApiKeyUsageStore.cs
+++ b/src/TextToSpeech.Providers.GoogleCloud/IApiKeyUsageStore.cs
@@ -32,10 +32,13 @@ public interface IApiKeyUsageStore
 /// Persisted snapshot of a single API key's usage and health. Loaded on startup
 /// and used to seed the in-memory state, with normalization applied: elapsed
 /// cooldowns reset to <see cref="ApiKeyState.Available"/>; counters reset when
-/// the persisted month no longer matches the current UTC month; and a key is
-/// forced to <see cref="ApiKeyState.MonthlyLimitExceeded"/> if its counter
-/// already meets the configured limit. The persisted record is therefore not
-/// applied verbatim - it is reconciled with current wall-clock state.
+/// the persisted month no longer matches the current UTC month; and a key
+/// otherwise <see cref="ApiKeyState.Available"/> is upgraded to
+/// <see cref="ApiKeyState.MonthlyLimitExceeded"/> when its persisted counter
+/// already meets the configured cap (other parked states such as
+/// <see cref="ApiKeyState.RateLimited"/> / <see cref="ApiKeyState.Invalid"/>
+/// are kept as persisted). The record is therefore not applied verbatim - it
+/// is reconciled with current wall-clock state.
 /// </summary>
 public sealed record ApiKeyUsageRecord
 {

--- a/tests/TextToSpeech.Providers.GoogleCloud.Tests/RoundRobinAndMonthlyCounterTests.cs
+++ b/tests/TextToSpeech.Providers.GoogleCloud.Tests/RoundRobinAndMonthlyCounterTests.cs
@@ -312,31 +312,49 @@ public class RoundRobinAndMonthlyCounterTests
     [Fact]
     public async Task PersistAsync_CollapsesBurstsToOneSavePerKey()
     {
-        // Hammer the provider with many calls. The bounded last-write-wins
-        // pipeline must NOT save once per call - it must collapse intermediate
-        // values. We expect saves <= calls (often dramatically less).
+        // Determinism trick: hold SaveAsync on a TaskCompletionSource so the
+        // worker can't drain while we're enqueuing. Push N synthesis calls;
+        // by the time we release the gate the persistence channel has
+        // accumulated duplicates that the worker collapses. Without bounded
+        // last-write-wins this would be ~callCount saves; with it, a handful.
         var saveCount = 0;
-        var store = new InMemoryStore(onSave: _ => Interlocked.Increment(ref saveCount));
+        var saveGate = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var store = new InMemoryStore(onSave: _ => Interlocked.Increment(ref saveCount))
+        {
+            BeforeSave = () => saveGate.Task
+        };
 
         var provider = BuildProvider(
-            secretValues: ["k-A"],
+            secretValues: ["k-A", "k-B", "k-C"],
             handler: new MockHttpMessageHandler(_ => SuccessResponse()),
             enableRoundRobin: true,
             monthlyLimit: 0,
             store: store);
 
-        const int callCount = 50;
+        await provider.WaitForHydrationAsync().WaitAsync(TimeSpan.FromSeconds(5));
+
+        const int callCount = 60;
         for (var i = 0; i < callCount; i++)
         {
             await provider.SynthesizeAsync(new TtsRequest { Text = "x" });
         }
 
-        // Drain settle window.
-        await Task.Delay(200);
+        saveGate.SetResult(true);
+
+        // Wait for the queue to settle: poll until saveCount stops climbing.
+        var prev = -1;
+        for (var i = 0; i < 100 && saveCount != prev; i++)
+        {
+            prev = saveCount;
+            await Task.Delay(20);
+        }
 
         Assert.True(saveCount > 0, "Expected at least one save");
-        Assert.True(saveCount <= callCount,
-            $"Save count {saveCount} should be <= call count {callCount} (channel must collapse bursts)");
+        // Tight upper bound: 3 keys, even allowing for a handful of drain
+        // cycles, total saves must be << callCount. Anything close to 60
+        // means the channel didn't collapse anything.
+        Assert.True(saveCount <= 12,
+            $"Save count {saveCount} should be <= 12 (3 keys x ~few drains); channel must collapse bursts. callCount={callCount}");
     }
 
     [Fact]
@@ -427,6 +445,7 @@ public class RoundRobinAndMonthlyCounterTests
     private sealed class InMemoryStore : IApiKeyUsageStore
     {
         public ConcurrentDictionary<string, ApiKeyUsageRecord> Records { get; } = new();
+        public Func<Task>? BeforeSave { get; set; }
         private readonly Action<ApiKeyUsageRecord>? _onSave;
 
         public InMemoryStore(Action<ApiKeyUsageRecord>? onSave = null) => _onSave = onSave;
@@ -434,11 +453,11 @@ public class RoundRobinAndMonthlyCounterTests
         public Task<ApiKeyUsageRecord?> LoadAsync(string keyName, CancellationToken cancellationToken = default)
             => Task.FromResult(Records.TryGetValue(keyName, out var r) ? r : null);
 
-        public Task SaveAsync(ApiKeyUsageRecord record, CancellationToken cancellationToken = default)
+        public async Task SaveAsync(ApiKeyUsageRecord record, CancellationToken cancellationToken = default)
         {
+            if (BeforeSave != null) await BeforeSave().ConfigureAwait(false);
             Records[record.KeyName] = record;
             _onSave?.Invoke(record);
-            return Task.CompletedTask;
         }
     }
 

--- a/tests/TextToSpeech.Providers.GoogleCloud.Tests/RoundRobinAndMonthlyCounterTests.cs
+++ b/tests/TextToSpeech.Providers.GoogleCloud.Tests/RoundRobinAndMonthlyCounterTests.cs
@@ -312,10 +312,11 @@ public class RoundRobinAndMonthlyCounterTests
     [Fact]
     public async Task PersistAsync_CollapsesBurstsToOneSavePerKey()
     {
-        // Determinism trick: hold SaveAsync on a TaskCompletionSource so the
-        // worker can't drain while we're enqueuing. Push N synthesis calls;
-        // by the time we release the gate the persistence channel has
-        // accumulated duplicates that the worker collapses. Without bounded
+        // Determinism trick: every SaveAsync awaits a TaskCompletionSource,
+        // so the worker can take a record off the queue but cannot complete
+        // a save until we release the gate. While the worker is parked
+        // mid-save, additional synthesis calls keep landing fresh records in
+        // _pendingPersists, which the next drain collapses. Without bounded
         // last-write-wins this would be ~callCount saves; with it, a handful.
         var saveCount = 0;
         var saveGate = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);


### PR DESCRIPTION
<!-- claude-session: ec307da9-6b00-4e2f-8f17-c5e21d3d09c6 -->

Follows up #21. Addresses every comment from Copilot's review.

## Summary
- **Hydration race fix (real bug)** — `SynthesizeAsync` and `GetInfoAsync` now await `_hydrationTask` before touching key state. Previously a synthesis call running concurrently with the background hydration could have its counter increments clobbered when hydration applied the older persisted values. After first await it's a no-op (IsCompletedSuccessfully fast-path), so steady-state cost is zero.
- **Doc accuracy** — `ApiKeyUsageRecord` description no longer says "Restored verbatim"; rewritten to describe the normalization (expired cooldown reset, stale-month counter reset, MonthlyLimitExceeded enforcement).
- **Burst-collapse test strengthened** — replaced `Task.Delay` + loose bound with a deterministic gate (`TaskCompletionSource` blocking SaveAsync). Now asserts <= 12 saves for 60 calls across 3 keys, where the previous bound would have passed even with no collapsing.

## Test plan
- [x] 30/30 GoogleCloud tests pass
- [ ] CI green
- [ ] Merge → NuGet `1.1.23+` auto-published
- [ ] VA picks up via `Version="1.*"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)